### PR TITLE
[FIX] Free up GPU memory after each image generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -242,6 +242,10 @@ def generate_image(face_image, pose_image, prompt, negative_prompt, style_name, 
 
     return images, gr.update(visible=True)
 
+def clearCudaCache():
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
 ### Description
 title = r"""
 <h1 align="center">InstantID: Zero-shot Identity-Preserving Generation in Seconds</h1>
@@ -393,6 +397,8 @@ with gr.Blocks(css=css) as demo:
             fn=generate_image,
             inputs=[face_files, pose_files, prompt, negative_prompt, style, enhance_face_region, num_steps, identitynet_strength_ratio, adapter_strength_ratio, guidance_scale, seed],
             outputs=[gallery, usage_tips]
+        ).then(
+            fn=clearCudaCache
         )
     
     gr.Examples(

--- a/app.py
+++ b/app.py
@@ -240,7 +240,7 @@ def generate_image(face_image, pose_image, prompt, negative_prompt, style_name, 
 
     return images, gr.update(visible=True)
 
-def clearCudaCache():
+def clear_cuda_cache():
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
 
@@ -396,7 +396,7 @@ with gr.Blocks(css=css) as demo:
             inputs=[face_files, pose_files, prompt, negative_prompt, style, enhance_face_region, num_steps, identitynet_strength_ratio, adapter_strength_ratio, guidance_scale, seed],
             outputs=[gallery, usage_tips]
         ).then(
-            fn=clearCudaCache
+            fn=clear_cuda_cache
         )
     
     gr.Examples(


### PR DESCRIPTION
# Issue encountered
After hitting submit and generating an image, the user can't generate a new image using the same environment because the GPU memory is still allocated by torch.cuda.

# Fix
To prevent having to kill the execution environment and run the Collab notebook all over again for each image, clear the cuda cache after image generation.

# Changes
- Define a new clear_cuda_cache function that verifies if torch is using cuda, and if so empties the cache to free up GPU memory.
- Call this function after calling generate_image in the chain of actions on the submit.onclick() event.